### PR TITLE
Fix UpdateScore packet

### DIFF
--- a/src/clientbound.rs
+++ b/src/clientbound.rs
@@ -311,8 +311,8 @@ impl UpdateScore {
         let action = read_u8(r)?;
         let objective_name = read_String(r)?;
         let value = match action {
-            1 => Some(read_varint(r)?),
-            _ => None,
+            1 => None,
+            _ => Some(read_varint(r)?),
         };
         Ok(ClientboundPacket::UpdateScore(UpdateScore {
                                               name: name,


### PR DESCRIPTION
The implementation of the UpdateScore packet had a bug where it reads an optional VarInt if the action was 1, but according to the protocol documentation this should be read when the action ***isn't*** 1.

https://wiki.vg/Protocol#Update_Score